### PR TITLE
Add WebConfig to Enable Cross-Origin Requests

### DIFF
--- a/app/src/main/java/com/handsonhip/config/WebConfig.java
+++ b/app/src/main/java/com/handsonhip/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.handsonhip.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}


### PR DESCRIPTION
Added a new WebConfig class to configure CORS (Cross-Origin Resource Sharing) settings.
Enabled CORS for all endpoints to allow the frontend application to interact with the backend without cross-origin issues.
Configured allowed origins, methods, and headers to ensure secure and flexible communication between frontend and backend.
This change is essential for local development and testing to facilitate seamless integration between the React frontend and Spring Boot backend applications.