### PR TITLE
Hashing passwords with salt

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,9 @@ dependencies {
     // Spring Boot Starter Data JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     
+    // Spring Security dependency
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     // PostgreSQL Driver
     implementation 'org.postgresql:postgresql'
     

--- a/app/src/main/java/com/handsonhip/config/SecurityConfig.java
+++ b/app/src/main/java/com/handsonhip/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package com.handsonhip.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import java.util.Collections; 
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+            .csrf(csrf -> csrf.disable())  // Disabled for testing purposes
+            .authorizeHttpRequests(authz -> authz
+                .requestMatchers("/api/member/register", "/api/member/login").permitAll()
+                .anyRequest().authenticated()
+            );
+        return http.build();  // Correctly return the SecurityFilterChain
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
+        configuration.setAllowedMethods(Collections.singletonList("*"));
+        configuration.setAllowedHeaders(Collections.singletonList("*"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/app/src/main/java/com/handsonhip/config/SecurityConfig.java
+++ b/app/src/main/java/com/handsonhip/config/SecurityConfig.java
@@ -8,7 +8,10 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import java.util.Collections; 
+
+import java.util.Arrays;
+import java.util.Collections;
+
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
@@ -22,17 +25,19 @@ public class SecurityConfig {
                 .requestMatchers("/api/member/register", "/api/member/login").permitAll()
                 .anyRequest().authenticated()
             );
-        return http.build();  // Correctly return the SecurityFilterChain
+        return http.build();
     }
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
-        configuration.setAllowedMethods(Collections.singletonList("*"));
-        configuration.setAllowedHeaders(Collections.singletonList("*"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("Content-Type", "Authorization"));
+        configuration.setAllowCredentials(true);  // This is important for credentials
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }
 }
+

--- a/app/src/main/java/com/handsonhip/config/WebConfig.java
+++ b/app/src/main/java/com/handsonhip/config/WebConfig.java
@@ -16,3 +16,4 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true);
     }
 }
+

--- a/app/src/main/java/com/handsonhip/controller/UserController.java
+++ b/app/src/main/java/com/handsonhip/controller/UserController.java
@@ -15,6 +15,8 @@ public class UserController {
 
     @PostMapping("/register")
     public ResponseEntity<String> register(@RequestBody User user) {
+        // Delete the following line later
+        System.out.println("Received registration request: " + user);
         if (userService.register(user)) {
             return ResponseEntity.ok("User registered successfully");
         } else {

--- a/app/src/main/java/com/handsonhip/model/User.java
+++ b/app/src/main/java/com/handsonhip/model/User.java
@@ -32,13 +32,15 @@ public class User {
     @Column(name = "password", nullable = false)
     private String password;
 
+    @Column(name = "salt", nullable = false)
+    private String salt;
+
     //No-arg constructor
     public User(){
-
     }
 
     //All-args constructor
-    public User(String firstName, String lastName, String address, String country, String city, String email, String password){
+    public User(String firstName, String lastName, String address, String country, String city, String email, String password, String salt){
         this.firstName = firstName;
         this.lastName = lastName;
         this.address = address;
@@ -46,6 +48,7 @@ public class User {
         this.city = city;
         this.email = email;
         this.password = password;
+        this.salt = salt;
     }
 
     // Getters and Setters
@@ -111,5 +114,13 @@ public class User {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public String getSalt() {
+        return salt;
+    }
+
+    public void setSalt(String salt) {
+        this.salt = salt;
     }
 }

--- a/app/src/main/java/com/handsonhip/model/User.java
+++ b/app/src/main/java/com/handsonhip/model/User.java
@@ -32,9 +32,6 @@ public class User {
     @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(name = "salt", nullable = false)
-    private String salt;
-
     //No-arg constructor
     public User(){
     }
@@ -48,7 +45,6 @@ public class User {
         this.city = city;
         this.email = email;
         this.password = password;
-        this.salt = salt;
     }
 
     // Getters and Setters
@@ -116,11 +112,4 @@ public class User {
         this.password = password;
     }
 
-    public String getSalt() {
-        return salt;
-    }
-
-    public void setSalt(String salt) {
-        this.salt = salt;
-    }
 }


### PR DESCRIPTION
Added Bcrpyt for secure password hashing.
- No need to define the salt manually, BCrypt decrypts using a standart in password format, passwords starts with $..$ when encrpyted. Old users cannot login due their password not matching the BCrypt standarts. 
Can test this in here;
https://bcrypt-generator.com/

Created a SecurityConfig.java file to configure CSRF protection.
- CSRF protection is disabled for testing and should be enabled by removing the disable() (default of it is enabled).
